### PR TITLE
[IMRF-7] Find and remove parts of constructors

### DIFF
--- a/src/Importify/Common.hs
+++ b/src/Importify/Common.hs
@@ -7,7 +7,7 @@ module Importify.Common
        ( Identifier (..)
        , collectImportsList
        , getImportModuleName
-       , importSpecToIdentifier
+       , importSpecToIdentifiers
        , importSlice
        , removeIdentifiers
        , removeImportIdentifier
@@ -20,7 +20,7 @@ import qualified Data.List.NonEmpty    as NE
 import           Data.Map.Strict       (Map)
 import qualified Data.Map.Strict       as M
 
-import           Language.Haskell.Exts (ImportDecl (..), ImportSpec (..),
+import           Language.Haskell.Exts (CName (..), ImportDecl (..), ImportSpec (..),
                                         ImportSpecList (..), ModuleName, Name (..),
                                         SrcSpan (..), SrcSpanInfo (..), combSpanInfo)
 
@@ -38,12 +38,15 @@ nameToIdentifier :: Name l -> Identifier
 nameToIdentifier (Ident  _ name) = Identifier name
 nameToIdentifier (Symbol _ name) = Identifier name
 
--- TODO: process all ctors of data type
-importSpecToIdentifier :: ImportSpec l -> Identifier
-importSpecToIdentifier (IVar _ name)              = nameToIdentifier name
-importSpecToIdentifier (IAbs _ _ name)            = nameToIdentifier name
-importSpecToIdentifier (IThingAll _ name)         = nameToIdentifier name
-importSpecToIdentifier (IThingWith _ name _cname) = nameToIdentifier name
+cnameToIdentifier :: CName l -> Identifier
+cnameToIdentifier (VarName _ name) = nameToIdentifier name
+cnameToIdentifier (ConName _ name) = nameToIdentifier name
+
+importSpecToIdentifiers :: ImportSpec l -> [Identifier]
+importSpecToIdentifiers (IVar _ name)              = [nameToIdentifier name]
+importSpecToIdentifiers (IAbs _ _ name)            = [nameToIdentifier name]
+importSpecToIdentifiers (IThingAll _ name)         = [nameToIdentifier name]
+importSpecToIdentifiers (IThingWith _ name cnames) = nameToIdentifier name:map cnameToIdentifier cnames
 
 
 -- | Converts list of 'ImportDecl' to 'Map' from 'Identifier' @id@ to be able
@@ -60,9 +63,15 @@ collectImportsList = foldr go mempty
                              -> ImportsListMap l
     updateWithImportSpecList dict _   (ImportSpecList _ True  _) = dict  -- True means is @hiding@
     updateWithImportSpecList dict imp (ImportSpecList _ False l) =
-        foldr (\spec -> M.insert (importSpecToIdentifier spec) (imp, spec)) dict l
+        foldr (\spec -> insertIdentifierList (importSpecToIdentifiers spec) (imp, spec)) dict l
+    insertIdentifierList :: [Identifier]
+                         -> (ImportDecl l, ImportSpec l)
+                         -> ImportsListMap l
+                         -> ImportsListMap l
+    insertIdentifierList ids imp dict =
+        foldr (\id -> M.insert id imp) dict ids
 
--- | Replace all entries in given list by applying given function
+-- | Replace first entry in given list by applying given function
 -- if predicate is @True@. After modification drop element from list if second
 -- given predicate is also @True@. This function is basically some smart combination
 -- of 'map' and 'filter'.
@@ -75,13 +84,27 @@ replaceOrDrop shouldBeConsidered shouldBeDropped update = go
                      if shouldBeDropped newX then xs else newX : xs
                 else x : go xs
 
-specListDelete :: Eq l => ImportSpec l -> ImportSpecList l -> Maybe (ImportSpecList l)
-specListDelete spec (ImportSpecList l b specs) = case delete spec specs of
+deleteSpecThing :: Identifier -> ImportSpec l -> Maybe (ImportSpec l)
+deleteSpecThing id (IThingWith l name cnames) = case newCnames of
+    [] -> Nothing
+    _  -> Just $ IThingWith l name newCnames
+  where
+    newCnames = filter isId cnames
+
+    isId :: CName l -> Bool
+    isId = (id ==) . cnameToIdentifier
+deleteSpecThing _ _ = error "deleteSpecThing got something else than IThingWith. That shouldn't happen"
+
+specListDelete :: Eq l => Maybe Identifier -> ImportSpec l -> ImportSpecList l -> Maybe (ImportSpecList l)
+specListDelete (Just id) spec specList@(ImportSpecList l b specs) = case deleteSpecThing id spec of
+    Nothing      -> specListDelete Nothing spec specList
+    Just newSpec -> Just (ImportSpecList l b (newSpec:(delete spec specs)))
+specListDelete Nothing spec (ImportSpecList l b specs) = case delete spec specs of
     [] -> Nothing
     sp -> Just $ ImportSpecList l b sp
 
-deleteImportSpec :: Eq l => ImportSpec l -> ImportDecl l -> ImportDecl l
-deleteImportSpec spec imp = imp {importSpecs = importSpecs imp >>= specListDelete spec }
+deleteImportSpec :: Eq l => Maybe Identifier -> ImportSpec l -> ImportDecl l -> ImportDecl l
+deleteImportSpec id spec imp = imp {importSpecs = importSpecs imp >>= specListDelete id spec }
 
 -- | Find 'ImportDecl' that contains given entry identifier and remove this entry
 -- from that import declaration.
@@ -91,15 +114,24 @@ removeImportIdentifier :: Eq l
                        -> [ImportDecl l]
                        -> ([ImportDecl l], ImportsListMap l)
 removeImportIdentifier id dict decls = case M.lookup id dict of
-    Nothing           -> (decls, dict)
-    Just (decl, spec) -> ( replaceOrDrop (eqByModule decl)
-                                         (isNothing . importSpecs)
-                                         (deleteImportSpec spec)
-                                         decls
-                         , M.delete id dict
-                         )
+    Nothing ->
+        (decls, dict)
+    Just (decl, spec@(IThingWith _ name _)) ->
+        removeUsing decl $ if id == nameToIdentifier name
+                           then deleteImportSpec Nothing spec
+                           else deleteImportSpec (Just id) spec
+    Just (decl, spec) ->
+        removeUsing decl (deleteImportSpec Nothing spec)
   where
     eqByModule = (==) `on` getImportModuleName
+    removeUsing decl deleteFunc =
+        ( replaceOrDrop (eqByModule decl)
+                        (isNothing . importSpecs)
+                        deleteFunc
+                        decls
+        , M.delete id dict
+        )
+
 
 -- | Removes list of 'Identifier's by calling 'removeImportIdentifier' and passing
 -- new result to the next recursive call.

--- a/src/Importify/Resolution.hs
+++ b/src/Importify/Resolution.hs
@@ -17,7 +17,7 @@ import qualified Language.Haskell.Names             as N
 import           Language.Haskell.Names.SyntaxUtils (stringToName)
 
 import           Importify.Common                   (Identifier (..),
-                                                     importSpecToIdentifier)
+                                                     importSpecToIdentifiers)
 
 symbolByName :: String -> [N.Symbol] -> Maybe N.Symbol
 symbolByName name symbols = head $ do
@@ -38,7 +38,7 @@ collectUnusedSymbols env decls annotations = do
     Just moduleSymbols <- guarded isJust $ M.lookup (() <$ importModule) env
     Just (ImportSpecList _ _ specs) <- guarded isJust importSpecs
     spec <- specs
-    let id@(Identifier name) = importSpecToIdentifier spec
+    id@(Identifier name) <- importSpecToIdentifiers spec
     Just symbol <- guarded isJust $ symbolByName name moduleSymbols
     guard $ isNothing (symbolUsages symbol annotations)
     pure id

--- a/test/BaseThingAllExample.hs
+++ b/test/BaseThingAllExample.hs
@@ -1,0 +1,7 @@
+module BaseThingAllExample where
+
+import           Language.Haskell.Exts (CName (..))
+import           System.IO (putStrLn)
+
+main :: IO ()
+main = putStrLn "Hello!"

--- a/test/BaseThingAllExample.hs
+++ b/test/BaseThingAllExample.hs
@@ -1,7 +1,12 @@
 module BaseThingAllExample where
 
+import           Data.Bool             (Bool (..))
+import           Data.Maybe            (Maybe (..))
 import           Language.Haskell.Exts (CName (..))
-import           System.IO (putStrLn)
+import           System.IO             (putStrLn)
+
+foo :: Bool
+foo = undefined
 
 main :: IO ()
 main = putStrLn "Hello!"

--- a/test/BaseThingWithExample.hs
+++ b/test/BaseThingWithExample.hs
@@ -1,7 +1,8 @@
 module BaseThingWithExample where
 
+import           Data.Bool             (Bool (False, True))
 import           Language.Haskell.Exts (DataOrNew (DataType))
-import           System.IO (putStrLn)
+import           System.IO             (putStrLn)
 
 main :: IO ()
-main = putStrLn "Hello!"
+main = putStrLn $ "Hello!" ++ show True

--- a/test/BaseThingWithExample.hs
+++ b/test/BaseThingWithExample.hs
@@ -1,0 +1,7 @@
+module BaseThingWithExample where
+
+import           Language.Haskell.Exts (DataOrNew (DataType))
+import           System.IO (putStrLn)
+
+main :: IO ()
+main = putStrLn "Hello!"


### PR DESCRIPTION
Constructors and methods are found while collecting the importMap and removed
with removeSymbols. There's another bug which prevents it from working properly
though.