### PR TITLE
[IMRF-13] Store sources of all dependencies in cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ cabal.project.local
 .HTF/
 
 *~
+haskell-names-0.8.0/

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ cabal.project.local
 
 *~
 haskell-names-0.8.0/
+.importify/

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -15,6 +15,7 @@ import           Language.Haskell.Exts  (Module (..), fromParseResult, parseFile
                                          prettyPrint)
 import           Language.Haskell.Names (annotate, loadBase)
 import           System.Directory       (createDirectory, doesDirectoryExist)
+import           Turtle                 (cd, pwd, shell)
 
 import           Importify.Cabal        (getLibs, readCabal)
 import           Importify.Cache        (cachePath)
@@ -56,8 +57,14 @@ importifySingleFile SingleFileOptions{..} = do
                <> unlines decls
 
 buildCabalCache :: CabalCacheOptions -> IO ()
-buildCabalCache CabalCacheOptions{..} = unlessM (doesDirectoryExist cachePath) $ do
+buildCabalCache CabalCacheOptions{..} = do
     cabalDesc <- readCabal ccoFilename
     let libs   = getLibs cabalDesc
+
     print libs
-    -- createDirectory cachePath
+
+    unlessM (doesDirectoryExist cachePath) $ createDirectory cachePath
+
+    -- move to cache directory and download-unpack all libs there
+    cd (fromString cachePath)
+    forM_ libs $ \libName -> () <$ shell ("stack unpack " <> toText libName) empty

--- a/app/Options.hs
+++ b/app/Options.hs
@@ -3,8 +3,11 @@
 -- | Command line options for Importify
 
 module Options
-       ( Command(..)
-       , SingleFileOptions(..)
+       ( Command (..)
+
+       , CabalCacheOptions (..)
+       , SingleFileOptions (..)
+
        , parseOptions
        ) where
 
@@ -16,20 +19,24 @@ import           Options.Applicative (Parser, ParserInfo, argument, command, exe
 
 data Command
     = SingleFile SingleFileOptions
+    | CabalCache CabalCacheOptions
+    deriving (Show)
 
 data SingleFileOptions = SingleFileOptions
-    { sfoFilename   :: !FilePath
-    -- ^ File to apply the tool to
-    }
+    { sfoFilename :: !FilePath -- ^ File to apply the tool to
+    } deriving (Show)
+
+data CabalCacheOptions = CabalCacheOptions
+    { ccoFilename :: !FilePath -- ^ Path to .cabal file
+    } deriving (Show)
 
 optionsParser :: Parser Command
-optionsParser =
-    subparser
-        (command
-            "file"
-            (info (helper <*> fileParser)
-                  (fullDesc <> progDesc "Importify a single file"))) <|>
-    fileParser
+optionsParser = subparser $
+    command "file" (info (helper <*> fileParser)
+                          (fullDesc <> progDesc "Importify a single file"))
+ <> command "cache" (info (helper <*> cacheParser)
+                           (fullDesc <> progDesc
+                              "Store cache from .cabal file in ./.importify folder"))
 
 fileParser :: Parser Command
 fileParser = do
@@ -37,6 +44,13 @@ fileParser = do
         metavar "FILE" <>
         help "File to importify"
     pure $ SingleFile SingleFileOptions{..}
+
+cacheParser :: Parser Command
+cacheParser = do
+    ccoFilename <- argument str $
+        metavar "FILE" <>
+        help "Path to .cabal file"
+    pure $ CabalCache CabalCacheOptions{..}
 
 optsInfo :: ParserInfo Command
 optsInfo = info

--- a/importify
+++ b/importify
@@ -1,0 +1,1 @@
+./.stack-work/install/x86_64-linux/lts-8.15/8.0.2/bin/importify

--- a/importify.cabal
+++ b/importify.cabal
@@ -14,12 +14,16 @@ cabal-version:       >=1.10
 
 library
   hs-source-dirs:      src
-  exposed-modules:     Importify.Common
+  exposed-modules:     Importify.Cabal
+                       Importify.Cache
+                       Importify.Common
                        Importify.Resolution
   build-depends:       base >= 4.7 && < 5
+                     , Cabal
                      , containers
                      , haskell-names
                      , haskell-src-exts
+                     , path
                      , universum
   default-language:    Haskell2010
   ghc-options:         -Wall -fno-warn-orphans
@@ -41,6 +45,7 @@ executable importify
   build-depends:       base
                      , importify
                      , containers
+                     , directory
                      , optparse-applicative
                      , haskell-src-exts
                      , haskell-names

--- a/importify.cabal
+++ b/importify.cabal
@@ -49,6 +49,7 @@ executable importify
                      , optparse-applicative
                      , haskell-src-exts
                      , haskell-names
+                     , turtle
                      , universum
   default-language:    Haskell2010
 

--- a/src/Importify/Cabal.hs
+++ b/src/Importify/Cabal.hs
@@ -1,0 +1,30 @@
+-- | This module contains common utilities for parsing .cabal files
+-- and manipulating it's AST.
+
+module Importify.Cabal
+       ( getLibs
+       , readCabal
+       ) where
+
+import           Universum
+
+import           Distribution.Package                  (Dependency (..), PackageName (..))
+import           Distribution.PackageDescription       (GenericPackageDescription (..),
+                                                        condTreeData, libBuildInfo,
+                                                        targetBuildDepends)
+import           Distribution.PackageDescription.Parse (readPackageDescription)
+import           Distribution.Verbosity                (normal)
+
+readCabal :: FilePath -> IO GenericPackageDescription
+readCabal = readPackageDescription normal
+
+-- TODO: also collect for executables and make unique
+-- TODO: what about version bounds?
+getLibs :: GenericPackageDescription -> [String]
+getLibs GenericPackageDescription{..} =
+    maybe []
+          (map dependencyName . targetBuildDepends . libBuildInfo . condTreeData)
+          condLibrary
+
+dependencyName :: Dependency -> String
+dependencyName (Dependency PackageName{..} _) = unPackageName

--- a/src/Importify/Cache.hs
+++ b/src/Importify/Cache.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+-- | This module contains common utilities for working with importify cache.
+
+module Importify.Cache
+       ( cachePath
+       ) where
+
+import           Universum
+
+import           Path      (Dir, Path, Rel, reldir, toFilePath)
+
+importifyCachePath :: Path Rel Dir
+importifyCachePath = [reldir|.importify/|]
+
+-- | Relative path to importify cache director: @.importify@
+cachePath :: FilePath
+cachePath = toFilePath importifyCachePath


### PR DESCRIPTION
Collect all dependencies for package and store it in cache directory.

WIP: now only printing of deps for library is working. Storing deps in progress.