### PR TITLE
[IMRF-15] Use cache from downloaded packages

### DIFF
--- a/src/Importify/CPP.hs
+++ b/src/Importify/CPP.hs
@@ -5,8 +5,8 @@
 -- @-XCPP@ extension in files.
 
 module Importify.CPP
-       ( parseWithCPP
-       , withModuleAST
+       ( parseModuleFile
+       , parseWithCPP
        ) where
 
 import           Universum
@@ -38,9 +38,11 @@ parseWithCPP pathToModule cabalExtensions = do
                                 (defaultParseMode { extensions = cabalExtensions })
                                 moduleFile
 
--- | Perform action with module AST if it parses successfully.
-withModuleAST :: Path Rel File -> [Extension] -> (Module SrcSpanInfo -> IO ()) -> IO ()
-withModuleAST pathToModule cabalExtensions action =
+-- | Parse 'Module' by given 'Path' with given 'Extension's converting
+-- parser errors into human readable text.
+parseModuleFile :: [Extension] -> Path Rel File -> IO $ Either Text $ Module SrcSpanInfo
+parseModuleFile cabalExtensions pathToModule =
     parseWithCPP pathToModule cabalExtensions >>= \case
-        ParseOk (moduleAST, _) -> action moduleAST
-        ParseFailed loc reason -> putText $ "Ignoring module cache := "#|MPE loc reason|#""
+        ParseOk (moduleAST, _) -> return $ Right moduleAST
+        ParseFailed loc reason -> return $ Left
+                                         $ "Ignoring module cache := "#|MPE loc reason|#""

--- a/src/Importify/Cabal.hs
+++ b/src/Importify/Cabal.hs
@@ -5,6 +5,7 @@ module Importify.Cabal
        ( getLibs
        , modulePaths
        , readCabal
+       , splitOnExposedAndOther
        , withLibrary
 
        -- * Map for extensions
@@ -20,6 +21,7 @@ import qualified Data.HashMap.Strict                   as Map
 import           Data.List                             (partition)
 import           Distribution.ModuleName               (ModuleName, fromString,
                                                         toFilePath)
+import qualified Distribution.ModuleName               as Cabal
 import           Distribution.Package                  (Dependency (..), PackageName (..))
 import           Distribution.PackageDescription       (BuildInfo (..), CondTree,
                                                         Executable (..),
@@ -37,14 +39,16 @@ import           System.Directory                      (doesFileExist)
 import           System.FilePath.Posix                 (dropExtension)
 import           Text.Read                             (read)
 
+import           Importify.Common                      (getModuleTitle)
+
 type TargetMap = HashMap String String
 type ExtensionsMap = HashMap String [String]
 
 readCabal :: FilePath -> IO GenericPackageDescription
 readCabal = readPackageDescription normal
 
-getNodeLibInfo :: CondTree var deps Library -> BuildInfo
-getNodeLibInfo = libBuildInfo . condTreeData
+-- getNodeLibInfo :: CondTree var deps Library -> BuildInfo
+-- getNodeLibInfo = libBuildInfo . condTreeData
 
 -- TODO: also collect for executables and make unique
 -- TODO: what about version bounds?
@@ -92,6 +96,15 @@ collectModuleMaps target mods exts =
 dependencyName :: Dependency -> String
 dependencyName (Dependency PackageName{..} _) = unPackageName
 
+-- | Split list of modules into /exposed/ modules and /other/ modules for given library.
+-- __First__ element of pair represents /exposed/ modules.
+-- __Second__ element of paris represents /other/ modules.
+splitOnExposedAndOther :: Library
+                       -> [HSE.Module HSE.SrcSpanInfo]
+                       -> ([HSE.Module HSE.SrcSpanInfo], [HSE.Module HSE.SrcSpanInfo])
+splitOnExposedAndOther Library{..} =
+    partition ((`elem` exposedModules) . Cabal.fromString . getModuleTitle)
+
 cabalExtToHseExt :: Extension -> HSE.Extension
 cabalExtToHseExt = {- trace ("Arg = " ++ show ext ++ "") -} read . show
 
@@ -114,7 +127,7 @@ withLibrary GenericPackageDescription{..} action =
             extensions    = filter isHseExt $ defaultExtensions ++ otherExtensions
         in action library (map cabalExtToHseExt extensions)
 
--- | Returns list of relative paths to each module.
+-- | Returns list of relative paths to both /exposed/ and /other/ modules.
 modulePaths :: Path Rel Dir -> Library -> IO [Path Rel File]
 modulePaths packagePath Library{..} = do
     let sourceDirs = hsSourceDirs libBuildInfo
@@ -124,22 +137,25 @@ modulePaths packagePath Library{..} = do
         ([]   , paths) -> collectModulesThere paths
         (_here, paths) -> liftA2 (++) collectModulesHere (collectModulesThere paths)
   where
-    exposedModulePaths :: IO [Path Rel File]
-    exposedModulePaths = mapM (parseRelFile . (++ ".hs") . toFilePath) exposedModules
+    thisLibModules :: [ModuleName]
+    thisLibModules = exposedModules ++ otherModules libBuildInfo
+
+    libModulePaths :: IO [Path Rel File]
+    libModulePaths = mapM (parseRelFile . (++ ".hs") . toFilePath) thisLibModules
 
     addDir :: Path Rel Dir -> [Path Rel File] -> [Path Rel File]
     addDir dir = map (dir </>)
 
     collectModulesHere :: IO [Path Rel File]
     collectModulesHere = do
-        paths <- exposedModulePaths
+        paths <- libModulePaths
         let packagePaths = addDir packagePath paths
         keepExistingModules packagePaths
 
     collectModulesThere :: [FilePath] -> IO [Path Rel File]
     collectModulesThere dirs = do
         dirPaths <- mapM parseRelDir dirs
-        modPaths <- exposedModulePaths
+        modPaths <- libModulePaths
         concatForM dirPaths $ \dir ->
           keepExistingModules $ addDir (packagePath </> dir) modPaths
 

--- a/src/Importify/Cache.hs
+++ b/src/Importify/Cache.hs
@@ -6,7 +6,8 @@ module Importify.Cache
        ( -- * Predefined directories
          cacheDir
        , cachePath
---       , libsDir
+       , modulesFile
+       , modulesPath
        , symbolsDir
        , symbolsPath
 
@@ -16,24 +17,25 @@ module Importify.Cache
 
 import           Universum
 
-import           Path            (Dir, File, Rel, fromRelDir, reldir)
+import           Path            (Dir, File, Rel, fromRelDir, fromRelFile, reldir,
+                                  relfile)
 import           Path.Internal   (Path (..))
 import           System.FilePath ((<.>))
 
 cachePath :: Path Rel Dir
 cachePath = [reldir|.importify/|]
 
--- TODO: do we need to store downloaded sources? Probably not.
--- libsPath :: Path Rel Dir
--- libsPath = importifyCachePath </> [reldir|libs|]
-
 symbolsPath :: Path Rel Dir
-symbolsPath = [reldir|symbols|]
+symbolsPath = [reldir|symbols/|]
 
-cacheDir, symbolsDir :: FilePath
-cacheDir   = fromRelDir cachePath
--- libsDir    = toFilePath libsPath
-symbolsDir = fromRelDir symbolsPath
+-- | Path to file that stores mapping from module names to their packages.
+modulesPath :: Path Rel File
+modulesPath = [relfile|modules|]
+
+cacheDir, modulesFile, symbolsDir :: FilePath
+cacheDir    = fromRelDir  cachePath
+modulesFile = fromRelFile modulesPath
+symbolsDir  = fromRelDir  symbolsPath
 
 -- TODO: probably not reliable, instead file with
 -- .cabal extension should be searched

--- a/src/Importify/Common.hs
+++ b/src/Importify/Common.hs
@@ -1,10 +1,12 @@
+{-# LANGUAGE ViewPatterns #-}
+
 -- | Common utilities for import list processing
 
 module Importify.Common
        ( Identifier (..)
        , cnameToIdentifier
        , getImportModuleName
-       , getModuleName
+       , getModuleTitle
        , getSourceModuleName
        , importSpecToIdentifiers
        , importSlice
@@ -14,15 +16,19 @@ module Importify.Common
 
 import           Universum
 
-import qualified Data.List.NonEmpty    as NE
+import qualified Data.List.NonEmpty                 as NE
 
-import           Language.Haskell.Exts (CName (..), Extension, ImportDecl (..),
-                                        ImportSpec (..), Module (..), ModuleHead (..),
-                                        ModuleName, ModuleName (..), Name (..),
-                                        NonGreedy (..), ParseResult (..),
-                                        PragmasAndModuleName (..), SrcSpan (..),
-                                        SrcSpanInfo (..), combSpanInfo, fromParseResult,
-                                        parse, parseFileContentsWithExts)
+import           Language.Haskell.Exts              (CName (..), Extension,
+                                                     ImportDecl (..), ImportSpec (..),
+                                                     Module (..), ModuleHead (..),
+                                                     ModuleName, ModuleName (..),
+                                                     Name (..), NonGreedy (..),
+                                                     ParseResult (..),
+                                                     PragmasAndModuleName (..),
+                                                     SrcSpan (..), SrcSpanInfo (..),
+                                                     combSpanInfo, fromParseResult, parse,
+                                                     parseFileContentsWithExts)
+import           Language.Haskell.Names.SyntaxUtils (getModuleName)
 
 -- | Returns module name for 'ImportDecl' with annotation erased.
 getImportModuleName :: ImportDecl l -> ModuleName ()
@@ -75,7 +81,6 @@ parseForImports exts fileContent = (ast, imports)
     where ast@(Module _ _ _ imports _) =
               fromParseResult $ parseFileContentsWithExts exts $ toString fileContent
 
--- | Maybe returns name of module.
-getModuleName :: Module l -> Maybe String
-getModuleName (Module _ (Just (ModuleHead _ (ModuleName _ name) _ _)) _ _ _) = Just name
-getModuleName _                                                              = Nothing
+-- | Returns name of 'Module' as a 'String'.
+getModuleTitle :: Module l -> String
+getModuleTitle (getModuleName -> ModuleName _ name) = name

--- a/src/Importify/Common.hs
+++ b/src/Importify/Common.hs
@@ -17,13 +17,11 @@ module Importify.Common
 import           Universum
 
 import qualified Data.List.NonEmpty                 as NE
-
 import           Language.Haskell.Exts              (CName (..), Extension,
                                                      ImportDecl (..), ImportSpec (..),
-                                                     Module (..), ModuleHead (..),
-                                                     ModuleName, ModuleName (..),
-                                                     Name (..), NonGreedy (..),
-                                                     ParseResult (..),
+                                                     Module (..), ModuleName,
+                                                     ModuleName (..), Name (..),
+                                                     NonGreedy (..), ParseResult (..),
                                                      PragmasAndModuleName (..),
                                                      SrcSpan (..), SrcSpanInfo (..),
                                                      combSpanInfo, fromParseResult, parse,

--- a/src/Importify/Main.hs
+++ b/src/Importify/Main.hs
@@ -17,7 +17,7 @@ import           Language.Haskell.Exts  (Extension, ImportDecl, Module (..),
                                          prettyPrint)
 import           Language.Haskell.Names (Environment, Scoped, annotate, loadBase,
                                          readSymbols, writeSymbols)
-import           Path                   (filename, fromAbsDir, fromAbsFile, fromRelFile,
+import           Path                   (fromAbsDir, fromAbsFile, fromRelFile,
                                          parseAbsDir, parseRelDir, parseRelFile, (</>))
 import           System.Directory       (createDirectoryIfMissing, doesFileExist,
                                          getCurrentDirectory, listDirectory,

--- a/src/Importify/Main.hs
+++ b/src/Importify/Main.hs
@@ -20,6 +20,7 @@ import           Path                   (filename, fromAbsDir, fromAbsFile, from
 import           System.Directory       (createDirectoryIfMissing, doesFileExist,
                                          getCurrentDirectory, listDirectory,
                                          removeDirectoryRecursive)
+import           System.FilePath        (dropExtension, takeFileName)
 import           Turtle                 (cd, shell)
 
 import           Importify.Cabal        (ExtensionsMap, TargetMap, getExtensionMaps,
@@ -107,8 +108,8 @@ doCache filepath preserve = do
     print libs
 
     -- download & unpack sources, then cache and delete
-    -- TODO: remove temp hacks
-    forM_ (filter (\p -> p /= "base" && p /= "importify") libs) $ \libName -> do
+    let projectName = dropExtension $ takeFileName filepath
+    forM_ (filter (\p -> p /= "base" && p /= projectName) libs) $ \libName -> do
         _exitCode            <- shell ("stack unpack " <> toText libName) empty
         localPackages        <- listDirectory importifyDir
         let maybePackage      = find (libName `isPrefixOf`) localPackages


### PR DESCRIPTION
This PR makes use of downloaded cache to remove redundant imports. `importify` was even used to remove some redundant imports from itself!