### PR TITLE
[IMRF-34] Make project cache itself

### DIFF
--- a/src/Importify/CPP.hs
+++ b/src/Importify/CPP.hs
@@ -19,7 +19,7 @@ import           Language.Haskell.Exts     (Comment, Extension, Module, ParseMod
 import qualified Language.Haskell.Exts     as LHE (SrcLoc)
 import           Language.Haskell.Exts.CPP (defaultCpphsOptions,
                                             parseFileWithCommentsAndCPP)
-import           Path                      (File, Path, Rel, fromRelFile)
+import           Path                      (Abs, File, Path, fromAbsFile)
 
 data ModuleParseException = MPE !LHE.SrcLoc !String
     deriving (Show)
@@ -31,16 +31,16 @@ instance Buildable ModuleParseException where
 -- | Parses file at given path without lines of c-preprocessor.
 -- Some additional handling is required because @haskell-src-exts@ can't
 -- handle @-XCPP@.
-parseWithCPP :: Path Rel File -> [Extension] -> IO $ ParseResult $ (Module SrcSpanInfo, [Comment])
+parseWithCPP :: Path Abs File -> [Extension] -> IO $ ParseResult $ (Module SrcSpanInfo, [Comment])
 parseWithCPP pathToModule cabalExtensions = do
-    let moduleFile = fromRelFile pathToModule
+    let moduleFile = fromAbsFile pathToModule
     parseFileWithCommentsAndCPP defaultCpphsOptions
                                 (defaultParseMode { extensions = cabalExtensions })
                                 moduleFile
 
 -- | Parse 'Module' by given 'Path' with given 'Extension's converting
 -- parser errors into human readable text.
-parseModuleFile :: [Extension] -> Path Rel File -> IO $ Either Text $ Module SrcSpanInfo
+parseModuleFile :: [Extension] -> Path Abs File -> IO $ Either Text $ Module SrcSpanInfo
 parseModuleFile cabalExtensions pathToModule =
     parseWithCPP pathToModule cabalExtensions >>= \case
         ParseOk (moduleAST, _) -> return $ Right moduleAST

--- a/test/system/TestImportify.hs
+++ b/test/system/TestImportify.hs
@@ -1,0 +1,7 @@
+-- getLibs
+module TestImportify where
+
+import           Importify.Cabal (getLibs)
+
+main :: IO ()
+main = pure ()


### PR DESCRIPTION
This PR fixes behavior of `importify` so now it also cache not only dependencies for project but also project itself. So this cache can be used later to interact with modules.