### PR TITLE
[#58] Remove useful hiding

### DIFF
--- a/src/Importify/Resolution/Hiding.hs
+++ b/src/Importify/Resolution/Hiding.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns    #-}
+
 -- | Name resolvers for @hiding@ imports.
 
 module Importify.Resolution.Hiding
@@ -6,6 +9,7 @@ module Importify.Resolution.Hiding
 
 import           Universum
 
+import           Language.Haskell.Exts  (Name)
 import           Language.Haskell.Names (NameInfo (Export, GlobalSymbol), Scoped)
 import qualified Language.Haskell.Names as N (Symbol (..))
 
@@ -18,11 +22,37 @@ hidingUsedIn :: N.Symbol -> [Scoped l] -> Bool
 hidingUsedIn symbol = anyAnnotation used
   where
     used :: NameInfo l -> Bool
-    used (GlobalSymbol global _) = modulelessEq symbol global
-    used (Export symbols)        = any (modulelessEq symbol) symbols
+    used (GlobalSymbol global _) = lossyCompare symbol global
+    used (Export symbols)        = any (lossyCompare symbol) symbols
     used _                       = False
+
+lossyCompare :: N.Symbol -> N.Symbol -> Bool
+lossyCompare (Fun name1) (Fun name2) = name1 == name2
+lossyCompare (Dat symb1) (Dat symb2) = modulelessEq symb1 symb2
+lossyCompare _           _           = False
 
 -- | Compares if two symbols are equal ignoring 'symbolModule'
 -- field. Used to remove imports from @hiding@ sections.
 modulelessEq :: N.Symbol -> N.Symbol -> Bool
 modulelessEq this other = this { N.symbolModule = N.symbolModule other } == other
+
+----------------------------------------------------------------------------
+-- Patterns for conveninet comparison
+----------------------------------------------------------------------------
+
+funPattern :: N.Symbol -> Maybe (Name ())
+funPattern N.Value{..}    = Just symbolName
+funPattern N.Method{..}   = Just symbolName
+funPattern N.Selector{..} = Just symbolName
+funPattern _              = Nothing
+
+datPattern :: N.Symbol -> Maybe N.Symbol
+datPattern symb = case funPattern symb of
+    Nothing -> Just symb
+    Just _  -> Nothing
+
+pattern Fun :: Name () -> N.Symbol
+pattern Fun name <- (funPattern -> Just name)
+
+pattern Dat :: N.Symbol -> N.Symbol
+pattern Dat symb <- (datPattern -> Just symb)

--- a/test/test-data/universum@prelude/01-UniversumShowMethod.golden
+++ b/test/test-data/universum@prelude/01-UniversumShowMethod.golden
@@ -1,0 +1,7 @@
+module UniversumShowMethodFun where
+
+import           Prelude   (show)
+import           Universum hiding (show)
+
+foo = show
+bar = (<<$>>)

--- a/test/test-data/universum@prelude/01-UniversumShowMethod.hs
+++ b/test/test-data/universum@prelude/01-UniversumShowMethod.hs
@@ -1,0 +1,7 @@
+module UniversumShowMethodFun where
+
+import           Prelude   (show)
+import           Universum hiding (show)
+
+foo = show
+bar = (<<$>>)

--- a/test/test-data/universum@prelude/02-UniversumBoolType.golden
+++ b/test/test-data/universum@prelude/02-UniversumBoolType.golden
@@ -1,0 +1,7 @@
+module UniversumBoolType where
+
+import           Prelude   (Bool)
+import           Universum hiding (Bool      )
+
+foo :: Bool
+foo = undefined

--- a/test/test-data/universum@prelude/02-UniversumBoolType.hs
+++ b/test/test-data/universum@prelude/02-UniversumBoolType.hs
@@ -1,0 +1,7 @@
+module UniversumBoolType where
+
+import           Prelude   (Bool)
+import           Universum hiding (Bool, show)
+
+foo :: Bool
+foo = undefined

--- a/test/test-data/universum@prelude/03-UniversumTrueBothUnused.golden
+++ b/test/test-data/universum@prelude/03-UniversumTrueBothUnused.golden
@@ -1,0 +1,7 @@
+module UniversumTrueBothUnused where
+
+import           Prelude   (Bool       )
+import           Universum hiding (Bool             )
+
+foo :: Bool
+foo = undefined

--- a/test/test-data/universum@prelude/03-UniversumTrueBothUnused.hs
+++ b/test/test-data/universum@prelude/03-UniversumTrueBothUnused.hs
@@ -1,0 +1,7 @@
+module UniversumTrueBothUnused where
+
+import           Prelude   (Bool (True))
+import           Universum hiding (Bool (True), show)
+
+foo :: Bool
+foo = undefined

--- a/test/test-data/universum@prelude/04-UniversumTrueHidingUnused.golden
+++ b/test/test-data/universum@prelude/04-UniversumTrueHidingUnused.golden
@@ -1,0 +1,8 @@
+module UniversumTrueHidingUnused where
+
+import           Prelude   (Bool (True))
+import           Universum hiding (Bool             )
+
+foo :: Bool
+foo = True
+bar = undefined

--- a/test/test-data/universum@prelude/04-UniversumTrueHidingUnused.hs
+++ b/test/test-data/universum@prelude/04-UniversumTrueHidingUnused.hs
@@ -1,0 +1,8 @@
+module UniversumTrueHidingUnused where
+
+import           Prelude   (Bool (True))
+import           Universum hiding (Bool (True), show)
+
+foo :: Bool
+foo = True
+bar = undefined

--- a/test/test-data/universum@prelude/05-UniversumHidingUnused.golden
+++ b/test/test-data/universum@prelude/05-UniversumHidingUnused.golden
@@ -1,0 +1,6 @@
+module Sandbox where
+
+import           Prelude   (Bool (True))
+
+foo :: Bool
+foo = True

--- a/test/test-data/universum@prelude/05-UniversumHidingUnused.hs
+++ b/test/test-data/universum@prelude/05-UniversumHidingUnused.hs
@@ -1,0 +1,7 @@
+module Sandbox where
+
+import           Prelude   (Bool (True))
+import           Universum hiding (Bool (True), show)
+
+foo :: Bool
+foo = True


### PR DESCRIPTION
This PR fixes issue when useful `hiding` was removed. The problem was in the difference between `Prelude.show` and `Universum.show`: in first case it's a method function, in second — top-level function. These both types of functions are represented differently and they were considered different.