### PR TITLE
Bump up dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,17 +25,13 @@ install:
   - stack ghc -- --version
 
   # Build only dependencies for project
-  - stack --jobs=2 build --only-snapshot --no-terminal
+  - stack --jobs=2 build --only-dependencies --no-terminal
 
-  # Build project itself with --coverage option to generate code coverage results
-  - stack --jobs=2 build --test --bench --coverage --no-run-tests --no-run-benchmarks --no-terminal
+  # Build project itself
+  - stack --jobs=2 build --test --bench --no-run-tests --no-run-benchmarks --no-terminal
 
 script:
-  - stack --jobs=4 test --coverage --no-terminal
-
-after_script:
-  - travis_retry curl -L https://github.com/rubik/stack-hpc-coveralls/releases/download/v0.0.4.0/shc-linux-x64-8.0.1.tar.bz2 | tar -xj
-  - ./shc importify importify-test
+  - stack --jobs=4 test --no-terminal
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://travis-ci.org/serokell/importify.svg)](https://travis-ci.org/serokell/importify)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Coverage Status](https://coveralls.io/repos/github/serokell/importify/badge.svg?branch=master)](https://coveralls.io/github/serokell/importify?branch=master)
 [![HLint Status](https://codeclimate.com/github/serokell/importify/badges/issue_count.svg)](https://codeclimate.com/github/serokell/importify)
 
 ## _Importify_ in a nutshell.

--- a/src/Extended/Data/List.hs
+++ b/src/Extended/Data/List.hs
@@ -7,8 +7,6 @@ module Extended.Data.List
 
 import           Universum
 
-import           Data.List (notElem)
-
 -- | Removes element from list by given index. If there's
 -- no element at such index then list returns unchanged.
 removeAt :: Int -> [a] -> [a]

--- a/src/Extended/System/Wlog.hs
+++ b/src/Extended/System/Wlog.hs
@@ -26,7 +26,7 @@ importifyLoggerConfig importifySeverity =
 
 -- | Initializes importify logger.
 initImportifyLogger :: MonadIO m => Severity -> m ()
-initImportifyLogger = setupLogging . importifyLoggerConfig
+initImportifyLogger = setupLogging Nothing . importifyLoggerConfig
 
 withImportify :: LoggerNameBox m a -> m a
 withImportify = usingLoggerName "importify"

--- a/src/Importify/Main/Cache.hs
+++ b/src/Importify/Main/Cache.hs
@@ -16,7 +16,6 @@ import           Universum
 import           Data.Aeson.Encode.Pretty        (encodePretty)
 import qualified Data.ByteString.Lazy            as LBS (writeFile)
 import qualified Data.HashMap.Strict             as HM
-import           Data.List                       (notElem)
 
 import           Distribution.PackageDescription (BuildInfo (includeDirs),
                                                   GenericPackageDescription)

--- a/src/Importify/ParseException.hs
+++ b/src/Importify/ParseException.hs
@@ -10,7 +10,7 @@ module Importify.ParseException
 
 import           Universum
 
-import           Fmt                   (Builder, blockListF, build, indent, (+|), (|+))
+import           Fmt                   (Builder, blockListF, build, indentF, (+|), (|+))
 import           Language.Haskell.Exts (ParseResult (..), SrcLoc (srcFilename),
                                         prettyPrint)
 
@@ -23,9 +23,9 @@ data ModuleParseException = MPE !SrcLoc !String
 instance Exception ModuleParseException
 instance Buildable ModuleParseException where
     build (MPE loc reason) = "Location:\n"
-                          +| indent 4 (build $ charWrap 80 $ prettyPrint loc)
+                          +| indentF 4 (build $ charWrap 80 $ prettyPrint loc)
                           |+ "Reason:\n"
-                          +| indent 4 (build $ wordWrap 80 reason)
+                          +| indentF 4 (build $ wordWrap 80 reason)
                           |+ ""
 
 -- | Updates file name of error location. Sometimes error location
@@ -43,7 +43,7 @@ eitherParseResult (ParseFailed loc reason) = Left $ MPE loc reason
 prettyParseErrors :: Text -> NonEmpty ModuleParseException -> Text
 prettyParseErrors libName exceptions =
     "Next errors occured during caching of package: "+|libName|+"\n"
- +| indent 4 (blockListF exceptions) |+ ""
+ +| indentF 4 (blockListF exceptions) |+ ""
 
 -- | Prints parse errors if list of errors is not empty.
 reportErrorsIfAny :: [ModuleParseException] -> Text -> IO ()

--- a/src/Importify/Resolution/Explicit.hs
+++ b/src/Importify/Resolution/Explicit.hs
@@ -13,8 +13,8 @@ import qualified Data.Map.Strict                          as M
 
 import           Language.Haskell.Exts                    (Module, ModuleName (..))
 import           Language.Haskell.Names                   (NameInfo (Export, GlobalSymbol),
-                                                           Scoped, resolve, symbolModule)
-import qualified Language.Haskell.Names                   as N (Symbol (..), symbolName)
+                                                           Scoped, Symbol (..), resolve,
+                                                           symbolModule)
 import           Language.Haskell.Names.GlobalSymbolTable (Table)
 
 import           Importify.Syntax                         (anyAnnotation)
@@ -22,21 +22,21 @@ import           Importify.Syntax                         (anyAnnotation)
 
 -- | Checks if 'Symbol' is used inside annotations. This function
 -- needed to remove unused imports.
-symbolUsedIn :: N.Symbol -> [Scoped l] -> Bool
+symbolUsedIn :: Symbol -> [Scoped l] -> Bool
 symbolUsedIn symbol = anyAnnotation used
   where
     used :: NameInfo l -> Bool
 
     -- Constructors are special because the whole type should be considered used
     -- if one of its constructors is used
-    used (GlobalSymbol global@(N.Constructor smodule _sname stype) _) =
+    used (GlobalSymbol global@(Constructor smodule _sname stype) _) =
         symbol == global ||
-        (N.symbolName symbol == stype && symbolModule symbol == smodule)
+        (symbolName symbol == stype && symbolModule symbol == smodule)
 
     -- ditto for selectors
-    used (GlobalSymbol global@(N.Selector smodule _sname stype _scons) _) =
+    used (GlobalSymbol global@(Selector smodule _sname stype _scons) _) =
         symbol == global ||
-        (N.symbolName symbol == stype && symbolModule symbol == smodule)
+        (symbolName symbol == stype && symbolModule symbol == smodule)
 
     -- Symbol is used as a part of export declaration
     used (Export symbols) = symbol `elem` symbols
@@ -47,9 +47,9 @@ symbolUsedIn symbol = anyAnnotation used
 
 -- | Collect symbols unused in annotations.
 collectUnusedSymbolsBy
-    :: (N.Symbol -> Bool) -- ^ 'True' iff 'Symbol' is used
+    :: (Symbol -> Bool) -- ^ 'True' iff 'Symbol' is used
     -> Table              -- ^ Mapping from imported names to their symbols
-    -> [N.Symbol]         -- ^ Returns list of unused symbols from 'Table'
+    -> [Symbol]         -- ^ Returns list of unused symbols from 'Table'
 collectUnusedSymbolsBy isUsed table = do
     -- 1. For every pair (entity, its symbols) in Table
     (_, importedSymbols) <- M.toList table
@@ -64,5 +64,5 @@ collectUnusedSymbolsBy isUsed table = do
     pure symbol
 
 -- | Gather all symbols for given list of 'Module's.
-resolveModules :: (Data l, Eq l) => [Module l] -> [(ModuleName (), [N.Symbol])]
+resolveModules :: (Data l, Eq l) => [Module l] -> [(ModuleName (), [Symbol])]
 resolveModules modules = M.toList $ resolve modules mempty

--- a/src/Importify/Resolution/Hiding.hs
+++ b/src/Importify/Resolution/Hiding.hs
@@ -10,15 +10,15 @@ module Importify.Resolution.Hiding
 import           Universum
 
 import           Language.Haskell.Exts  (Name)
-import           Language.Haskell.Names (NameInfo (Export, GlobalSymbol), Scoped)
-import qualified Language.Haskell.Names as N (Symbol (..))
+import           Language.Haskell.Names (NameInfo (Export, GlobalSymbol), Scoped,
+                                         Symbol (..))
 
 import           Importify.Syntax       (anyAnnotation)
 
 -- | Checks if given 'Symbol' is used in module annotations. This
 -- function performs comparison by ignoring module names because we want
 -- to remove @hiding@ by calling this function.
-hidingUsedIn :: N.Symbol -> [Scoped l] -> Bool
+hidingUsedIn :: Symbol -> [Scoped l] -> Bool
 hidingUsedIn symbol = anyAnnotation used
   where
     used :: NameInfo l -> Bool
@@ -26,33 +26,33 @@ hidingUsedIn symbol = anyAnnotation used
     used (Export symbols)        = any (lossyCompare symbol) symbols
     used _                       = False
 
-lossyCompare :: N.Symbol -> N.Symbol -> Bool
+lossyCompare :: Symbol -> Symbol -> Bool
 lossyCompare (Fun name1) (Fun name2) = name1 == name2
 lossyCompare (Dat symb1) (Dat symb2) = modulelessEq symb1 symb2
 lossyCompare _           _           = False
 
 -- | Compares if two symbols are equal ignoring 'symbolModule'
 -- field. Used to remove imports from @hiding@ sections.
-modulelessEq :: N.Symbol -> N.Symbol -> Bool
-modulelessEq this other = this { N.symbolModule = N.symbolModule other } == other
+modulelessEq :: Symbol -> Symbol -> Bool
+modulelessEq this other = this { symbolModule = symbolModule other } == other
 
 ----------------------------------------------------------------------------
 -- Patterns for conveninet comparison
 ----------------------------------------------------------------------------
 
-funPattern :: N.Symbol -> Maybe (Name ())
-funPattern N.Value{..}    = Just symbolName
-funPattern N.Method{..}   = Just symbolName
-funPattern N.Selector{..} = Just symbolName
-funPattern _              = Nothing
+funPattern :: Symbol -> Maybe (Name ())
+funPattern Value{..}    = Just symbolName
+funPattern Method{..}   = Just symbolName
+funPattern Selector{..} = Just symbolName
+funPattern _            = Nothing
 
-datPattern :: N.Symbol -> Maybe N.Symbol
+datPattern :: Symbol -> Maybe Symbol
 datPattern symb = case funPattern symb of
     Nothing -> Just symb
     Just _  -> Nothing
 
-pattern Fun :: Name () -> N.Symbol
+pattern Fun :: Name () -> Symbol
 pattern Fun name <- (funPattern -> Just name)
 
-pattern Dat :: N.Symbol -> N.Symbol
+pattern Dat :: Symbol -> Symbol
 pattern Dat symb <- (datPattern -> Just symb)

--- a/src/Importify/Resolution/Implicit.hs
+++ b/src/Importify/Resolution/Implicit.hs
@@ -8,19 +8,17 @@ module Importify.Resolution.Implicit
 
 import           Universum
 
-import           Data.List                     (notElem)
 import qualified Data.Map.Strict               as M
 
 import           Language.Haskell.Exts         (ImportDecl (..), ModuleName (..))
-import           Language.Haskell.Names        (Environment)
-import qualified Language.Haskell.Names        as N (Symbol (..))
+import           Language.Haskell.Names        (Environment, Symbol)
 
 import           Importify.Resolution.Explicit (collectUnusedSymbolsBy)
 import           Importify.Syntax              (InScoped, getImportModuleName,
                                                 importNamesWithTables, isImportImplicit)
 
 -- | Collect names of unused implicit imports.
-collectUnusedImplicitImports :: (N.Symbol -> Bool)
+collectUnusedImplicitImports :: (Symbol -> Bool)
                              -> [InScoped ImportDecl]
                              -> [ModuleName ()]
 collectUnusedImplicitImports isUsed imports =

--- a/src/Importify/Stack.hs
+++ b/src/Importify/Stack.hs
@@ -22,7 +22,7 @@ import           Universum
 
 import qualified Control.Foldl        as Fold (head, list)
 import qualified Data.HashMap.Strict  as HM
-import           Data.List            (notElem, partition)
+import           Data.List            (partition)
 import qualified Data.Text            as T
 import           Data.Yaml            (FromJSON (parseJSON), Parser, Value (Object),
                                        decodeEither', prettyPrintParseException,
@@ -83,10 +83,6 @@ stackProjectRoot = do
   where
     eitherParseRoot :: Text -> Either SomeException (Path Abs Dir)
     eitherParseRoot = parseAbsDir . toString
-
--- TODO: remove after universum update to 0.6
-guardM :: MonadPlus m => m Bool -> m ()
-guardM f = guard =<< f
 
 -- | Extract all dependencies with versions using
 -- @stack list-dependencies@ shell command.

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,13 +1,14 @@
-resolver: lts-8.24
+resolver: lts-9.6
 
 packages: ['.']
 
 extra-deps:
-- universum-0.5.1
-- fmt-0.4.0.0
+- fmt-0.5.0.0
+- haskell-names-0.9.0
+- log-warper-1.3.2
 - path-0.6.1
 - path-io-1.3.3
-- log-warper-1.1.4
+- universum-0.7.0
 
 flags: {}
 extra-package-dbs: []


### PR DESCRIPTION
Also remove codecoverage integration
Most important bump up is to haskell-names-0.9.0
which allows to use records extensively.