### PR TITLE
[#67] Added nix compatibility

### DIFF
--- a/src/Extended/System/Wlog.hs
+++ b/src/Extended/System/Wlog.hs
@@ -13,13 +13,15 @@ import           Universum
 
 import           Lens.Micro.Platform (zoom, (?=))
 import           System.Wlog         (LoggerConfig, LoggerNameBox, Severity (..),
-                                      consoleOutB, lcTree, logDebug, logError, logInfo,
-                                      logNotice, logWarning, ltSeverity, setupLogging,
-                                      usingLoggerName, zoomLogger)
+                                      consoleOutB, lcTermSeverity, lcTree, logDebug,
+                                      logError, logInfo, logNotice, logWarning,
+                                      ltSeverity, setupLogging, usingLoggerName,
+                                      zoomLogger)
 
 importifyLoggerConfig :: Severity -> LoggerConfig
-importifyLoggerConfig importifySeverity =
-    executingState consoleOutB $ zoom lcTree $ do
+importifyLoggerConfig importifySeverity = executingState consoleOutB $ do
+    lcTermSeverity ?= importifySeverity
+    zoom lcTree $ do
         ltSeverity ?= Warning
         zoomLogger "importify" $
             ltSeverity ?= importifySeverity

--- a/src/Importify/Stack.hs
+++ b/src/Importify/Stack.hs
@@ -40,7 +40,7 @@ import           Extended.System.Wlog (printWarning)
 shStack :: [Text] -> Shell Line
 shStack args = do
   inNix <- inNixShell
-  inproc "stack" (if inNix then ("--nix" : args) else args) empty
+  inproc "stack" (if inNix then "--nix" : args else args) empty
 
 -- | Checks if running in nix shell
 inNixShell :: MonadIO m => m Bool

--- a/src/Importify/Stack.hs
+++ b/src/Importify/Stack.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE ExplicitForAll      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE OverloadedStrings   #-}
 
 -- | Utilities which allows to use @stack@ tools for different
 -- dependencies stuff.
@@ -31,13 +32,21 @@ import           Path                 (Abs, Dir, Path, PathException, dirname, f
                                        mkRelDir, parent, parseAbsDir, (</>))
 import           Path.IO              (doesDirExist)
 import           System.FilePath      (splitPath)
-import           Turtle               (Line, Shell, inproc, lineToText, linesToText)
+import           Turtle               (Line, Shell, inproc, lineToText, linesToText, need)
 import qualified Turtle               (fold)
 
 import           Extended.System.Wlog (printWarning)
 
 shStack :: [Text] -> Shell Line
-shStack args = inproc "stack" args empty
+shStack args = do
+  inNix <- inNixShell
+  inproc "stack" (if inNix then ("--nix" : args) else args) empty
+
+-- | Checks if running in nix shell
+inNixShell :: MonadIO m => m Bool
+inNixShell = do
+  ns <- need "IN_NIX_SHELL"
+  pure $ maybe False (== "1") ns
 
 pathArgs, rootArgs, depsArgs :: [Text]
 pathArgs = ["path", "--compiler-bin"]

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,3 +12,6 @@ extra-deps:
 
 flags: {}
 extra-package-dbs: []
+
+nix:
+    packages: [stack]

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,4 +14,4 @@ flags: {}
 extra-package-dbs: []
 
 nix:
-    packages: [stack]
+    packages: [stack, binutils]


### PR DESCRIPTION
If stack is launched with `--nix`, now nix will take care of the missing dependencies:

- binutils for `strip`
- stack for running tests

and additionally the stack instances that is launched for testing will receive the `--nix` flag as well to have access to the right ghc version