### PR TITLE
fix up some English and compiler warnings

### DIFF
--- a/BinariesVersionCheck.sh
+++ b/BinariesVersionCheck.sh
@@ -1,0 +1,8 @@
+ghc --version
+stack --version
+cabal --version
+hlint --version
+hindent --version
+hpack --version
+
+

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ In the future, we plan for _Importify_ to be able to:
 
 ## Installation
 
-Installation process assumes that you have already installed and configured `stack`
+Installation process assumes that you have already installed and configured the `stack`
 build tool. Currently `importify` works only with projects built with `stack`.
 
-Perform the next steps before driving:
+Perform the following steps before driving:
 
 ```bash
 $ git clone https://github.com/serokell/importify.git  # 1. Clone repository locally
@@ -51,7 +51,7 @@ $ stack install importify\:exe\:importify              # 3. Copy executable unde
 In short:
 
 ```bash
-$ cd my-project-which-build-with-stack
+$ cd my-project-which-builds-with-stack
 $ importify cache
 $ importify file path/to/File/With/Unused/Imports.hs
 ```
@@ -69,8 +69,8 @@ entities for each module for every dependency and for all your local
 packages. Make sure to re-run `importify cache` if you change the list
 of exported functions and types in your project modules. Cache is
 built incrementally; it builds dependencies only once. But if you add
-dependencies or use other versions of them (for instance, because of
-bumping stack lts) you need to run `importify cache` again. You can
+dependencies or use other versions of them 
+(for instance, bumping stack lts) you need to run `importify cache` again. You can
 always perform `rm -rf .importify` before caching if you face any
 troubles.
 

--- a/importify.cabal
+++ b/importify.cabal
@@ -1,5 +1,5 @@
 name:                importify
-version:             1.0
+version:             1.1
 synopsis:            Tool for haskell imports refactoring
 description:         Please see README.md
 homepage:            https://github.com/serokell/importify

--- a/src/Importify/Cabal/Module.hs
+++ b/src/Importify/Cabal/Module.hs
@@ -9,7 +9,7 @@ module Importify.Cabal.Module
 import           Universum                       hiding (fromString)
 
 import           Data.List                       (partition)
-import           Distribution.ModuleName         (ModuleName, fromString, toFilePath)
+import           Distribution.ModuleName         (ModuleName, toFilePath)
 import qualified Distribution.ModuleName         as Cabal
 import           Distribution.PackageDescription (BuildInfo (..), Library (..))
 import qualified Language.Haskell.Exts           as HSE

--- a/src/Importify/Main/Cache.hs
+++ b/src/Importify/Main/Cache.hs
@@ -74,7 +74,7 @@ importifyCacheProject :: RIO CacheEnvironment ()
 importifyCacheProject = do
     (localPackages@(LocalPackages locals), remotePackages) <- stackListPackages
     if null locals
-    then printWarning "No packages found :( This could happen due to next reasons:\n\
+    then printWarning "No packages found :( This could happen due to the following reasons:\n\
                       \    1. Not running from project root directory.\n\
                       \    2. 'stack query' command failure.\n\
                       \    3. Our failure in parsing 'stack query' output."

--- a/src/Importify/Main/File.hs
+++ b/src/Importify/Main/File.hs
@@ -14,10 +14,10 @@ import           Universum
 import qualified Data.HashMap.Strict                as HM
 import qualified Data.Map                           as M
 
-import           Fmt                                (fmt, (+|), (|+))
+import           Fmt                                ( (+|), (|+))       --mjh   was (fmt, ...
 import           Language.Haskell.Exts              (Extension, ImportDecl, Module (..),
                                                      ModuleHead, ModuleName (..),
-                                                     SrcSpanInfo, exactPrint,
+                                                     SrcSpanInfo,  --mjh exactPrint
                                                      parseExtension,
                                                      parseFileContentsWithExts)
 import           Language.Haskell.Names             (Environment, Scoped, annotate,

--- a/src/Importify/ParseException.hs
+++ b/src/Importify/ParseException.hs
@@ -42,7 +42,7 @@ eitherParseResult (ParseFailed loc reason) = Left $ MPE loc reason
 -- | Pretty printing 'NonEmpty' list of errors in really nice way.
 prettyParseErrors :: Text -> NonEmpty ModuleParseException -> Text
 prettyParseErrors libName exceptions =
-    "Next errors occured during caching of package: "+|libName|+"\n"
+    "The following errors occured during caching of package: "+|libName|+"\n"
  +| indentF 4 (blockListF exceptions) |+ ""
 
 -- | Prints parse errors if list of errors is not empty.

--- a/src/Importify/Resolution/Qualified.hs
+++ b/src/Importify/Resolution/Qualified.hs
@@ -55,7 +55,7 @@ possiblyUnusedImport unusedImplicits decl = isNothing (importSpecs decl)
                       ==> getImportModuleName decl `elem` unusedImplicits
 
 -- | For given import collect qualified name.
--- Qualified names gathered using next scheme:
+-- Qualified names gathered using the following scheme:
 -- @
 --   import           A      ⇒ Nothing
 --   import qualified B      ⇒ Just B

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,3 +15,4 @@ extra-package-dbs: []
 
 nix:
     packages: [stack, binutils]
+

--- a/stackSeq.sh
+++ b/stackSeq.sh
@@ -1,0 +1,4 @@
+stack --version && stack clean && stack build && stack install && stack sdist && stack test && stack list-dependencies
+
+
+


### PR DESCRIPTION
I have enjoyed working with importify and it could be quite useful. I started on a 4 core machine and all went went and then decided to use a twin core and had compilation issues. I fixed up a few bits of English and enjoy working on code from other people especially when it builds OK.  I am quite new but enthusiastic with Haskell.

I have made a pull request  to change a few minor warnings and mistakes. 